### PR TITLE
Avoid panic by checking if returned secrets are nil

### DIFF
--- a/cmd/vaultify/vaultify.go
+++ b/cmd/vaultify/vaultify.go
@@ -3,9 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/spf13/pflag"
 	"os"
 	"time"
+
+	"github.com/spf13/pflag"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/spf13/cobra"

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -10,3 +10,7 @@ func Serve(addr string) {
 	healthz.Register()
 	ghttp.ListenAndServe(addr, nil)
 }
+
+func NewDefaultMux() {
+	ghttp.DefaultServeMux = new(ghttp.ServeMux)
+}

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -92,6 +92,6 @@ func IncSecretLeaseFailed(role string, secret string) {
 	}).Inc()
 }
 
-func RegisterHandler(metricsPath string)  {
+func RegisterHandler(metricsPath string) {
 	http.Handle(metricsPath, promhttp.Handler())
 }


### PR DESCRIPTION
This PR checks if renewed secrets are empty and creates a retry loop that is reusing `options.MaxRetries`.